### PR TITLE
Opt into using Nodejs v24 for our workflows, before GitHub deprecates…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      # Let's try opting into use of Nodejs v24; see:
+      #  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+      # GitHub runners still causing problems with NodeJS v20; see:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     strategy:
       matrix:
         compiler:
@@ -28,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout ProFTPD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: proftpd/proftpd
           path: proftpd
 
       - name: Checkout module source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: proftpd-mod_autohost
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      # Let's try opting into use of Nodejs v24; see:
+      #  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+      # GitHub runners still causing problems with NodeJS v20; see:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     strategy:
       fail-fast: true
       matrix:
@@ -31,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout ProFTPD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: proftpd/proftpd
 
       - name: Checkout mod_autohost
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: proftpd-mod_autohost
 


### PR DESCRIPTION
… Nodejs v20.